### PR TITLE
[Feature/Fix] Fix to avoid breaking machine's default python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # PWD_Vault
 
-
-
 PWD_Vault is a versatile everyday use password manager tool.
 
 This program uses encryption to store your password, which can only be decrypted and viewed within the program.
@@ -16,19 +14,20 @@ Download the zip via `github.com/nightmare-tech/PWD_Vault` or clone it via git :
 ```
 git clone https://nightmare-tech/PWD_Vault
 ```
-    
-   It is a very small repository. So, I didn't need another way to install it. And it’s the easiest :)
-
+It is a very small repository. So, I didn't need another way to install it. And it’s the easiest :)
 
 # Run Locally:
-!!!! Ensure that you have install the necessary packages before running the script !!!!
+### Create a virtual env so that it does not break default lib versions 
 ```
-pip install cryptography
-pip install passlib
-pip install pandas
+cd PWD_Vault
+python -m venv .
+source bin/activate
 ```
+!!!  Install the necessary packages !!!
 
-Alternatively, You could run `pip install -r requirements.txt` to install the above packages
+```
+pip install -r requirements.txt
+```
 
 - For Windows users:
     Click on the batch file `PWD_Vault.bat` from your file manager or execute the batch file by typing


### PR DESCRIPTION
Issue:
 When I tried the installation steps it broke my machine's default pandas and other libs.
 
Change: 
I am suggesting here with this PR to add a virtual env so that it does not break or impact existing libs.

Nice work. The code is simple and its interesting small project to learn. 